### PR TITLE
only show even months to bring back dates #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Copy `config.json.sample` to `config.json` and edit the following values:
 - `api_response_cache_dir`: Fully qualified directory where JSON files representing API responses will be stored.
 - `aggregate_output_dir`: Fully qualified directory where TSV output files of aggregated metrics will be stored.
 - `num_months_to_process`: For monthly metrics, the number of months to go back in time to download metrics from each Dataverse installation.
+- `month_filter_enabled`: If you have `num_months_to_process` set high (e.g. 36 months) the dates will disappear from the bottom of the bar charts. Changing this boolean to true will make only even months appear and with fewer bars the dates will be visible.
 - `endpoints`: An array of Metrics API endpoints to process. Note that the two types are `single` (i.e. `datasets/bySubject`) and `monthly` (i.e. `downloads/toMonth`). (You will notice a third type called `monthly_itemized` in `config.json.sample` but it is not yet supported.)
 - `blacklists`: Arrays of terms to blacklist. Only the `datasets/bySubject` endpoint can have a blacklist.
 - `colors`: A single color for bar charts and a palette of colors for tree maps.

--- a/config.json.sample
+++ b/config.json.sample
@@ -18,6 +18,7 @@
   "api_response_cache_dir": "/var/www/html/dataverse-metrics/cache",
   "aggregate_output_dir": "/var/www/html/dataverse-metrics",
   "num_months_to_process": 12,
+  "month_filter_enabled": false,
   "endpoints": {
     "single": [
       "dataverses/byCategory",

--- a/plots.js
+++ b/plots.js
@@ -14,8 +14,14 @@ $(document).ready(function() {
 
 function dataversesToMonth(config) {
     var color = config["colors"]["dataverses/toMonth"];
+    var month_filter_enabled = config["month_filter_enabled"];
     d3.tsv("dataverses-toMonth.tsv", function(error, data) {
         if (error) return console.error(error);
+        if (month_filter_enabled) {
+            data = data.filter(function(d) {
+                return parseInt(d.month.split('-')[1]) % 2 == 0;
+            })
+        }
         coerceToNumeric(data);
         var yLabel = "Number of Dataverses";
         var visualization = d3plus.viz()
@@ -88,8 +94,14 @@ function dataversesByCategory(config) {
 
 function datasetsToMonth(config) {
     var color = config["colors"]["datasets/toMonth"];
+    var month_filter_enabled = config["month_filter_enabled"];
     d3.tsv("datasets-toMonth.tsv", function(error, data) {
         if (error) return console.error(error);
+        if (month_filter_enabled) {
+            data = data.filter(function(d) {
+                return parseInt(d.month.split('-')[1]) % 2 == 0;
+            })
+        }
         coerceToNumeric(data);
         var yLabel = "Number of Datasets";
         var visualization = d3plus.viz()
@@ -166,8 +178,14 @@ function datasetsBySubject(config) {
 
 function filesToMonth(config) {
     var color = config["colors"]["files/toMonth"];
+    var month_filter_enabled = config["month_filter_enabled"];
     d3.tsv("files-toMonth.tsv", function(error, data) {
         if (error) return console.error(error);
+        if (month_filter_enabled) {
+            data = data.filter(function(d) {
+                return parseInt(d.month.split('-')[1]) % 2 == 0;
+            })
+        }
         coerceToNumeric(data);
         var yLabel = "Number of Files";
         var visualization = d3plus.viz()
@@ -205,8 +223,14 @@ function filesToMonth(config) {
 
 function downloadsToMonth(config) {
     var color = config["colors"]["downloads/toMonth"];
+    var month_filter_enabled = config["month_filter_enabled"];
     d3.tsv("downloads-toMonth.tsv", function(error, data) {
         if (error) return console.error(error);
+        if (month_filter_enabled) {
+            data = data.filter(function(d) {
+                return parseInt(d.month.split('-')[1]) % 2 == 0;
+            })
+        }
         coerceToNumeric(data);
         var yLabel = "Number of File Downloads";
         var visualization = d3plus.viz()


### PR DESCRIPTION
Closes #22 

This pull request introduces a new `month_filter_enabled` boolean to only show the even months in the plot as a way to get the dates back when there are 36 months.

## Before

![Screen Shot 2019-05-30 at 3 36 23 PM](https://user-images.githubusercontent.com/21006/58659918-2242a400-82f2-11e9-8b1d-928be4ac4fbb.png)


## After

![Screen Shot 2019-05-30 at 3 42 52 PM](https://user-images.githubusercontent.com/21006/58659836-f58e8c80-82f1-11e9-9d46-5480894b82c8.png)
