### PR TITLE
base url only for cifor

### DIFF
--- a/all-dataverse-installations.json
+++ b/all-dataverse-installations.json
@@ -74,7 +74,7 @@
       "lat": -6.594293,
       "lng": 106.806,
       "logo": "https://dvn-h-prod.hz.lib.harvard.edu/media/logos/CIFOR-46x46.png",
-      "url": "https://data.cifor.org/dataverse/s",
+      "url": "https://data.cifor.org",
       "slug": "cifor",
       "version": "4.6"
     },


### PR DESCRIPTION
Correcting the mismatch @donsizemore and I talked about at http://irclog.iq.harvard.edu/dataverse/2019-07-03#i_99768