### PR TITLE
Request json formatted downloads to be compatible with Dataverse #7178

### DIFF
--- a/download.py
+++ b/download.py
@@ -55,7 +55,9 @@ def process_monthly_endpoint(installation, endpoint, api_response_cache_dir, num
         if not os.path.exists(path):
             os.makedirs(path)
         try: 
-            response = urlrequest.urlopen(url)
+            req = urlrequest.Request(url)
+            req.add_header('Accept', 'application/json')
+            response = urlrequest.urlopen(req)
         except: 
             # assume that this endpoint is not supported by this (older) Dataverse instance - skip quietly (?)
             break
@@ -102,7 +104,9 @@ def process_single_endpoints(installation, single_endpoints, api_response_cache_
 def process_single_endpoint(installation, endpoint, api_response_cache_dir):
     url = installation + '/api/info/metrics/' + endpoint
     try:
-        response = urlrequest.urlopen(url)
+        req = urlrequest.Request(url)
+        req.add_header('Accept', 'application/json')
+        response = urlrequest.urlopen(req)
     except Exception as e:
         print(installation + " had an oops: " + str(e))
     json_out = get_remote_json(response)


### PR DESCRIPTION
This PR is the minimal update to stay compatible with instances of Dataverse running a release after the merge of [#7178](https://github.com/IQSS/dataverse/pull/7178). The changes here are backward compatible with older Dataverse versions.