### PR TITLE
Adding a message about drop in dataset #s

### DIFF
--- a/plots.js
+++ b/plots.js
@@ -110,6 +110,7 @@ function datasetsToMonth(config) {
             .title({
                "sub": "Due to an aggregation issue, current count does not include ~82,000 datasets from https://data.inrae.fr",
                "total": true
+            })
             .container("#datasets-to-month")
             .type("bar")
             .id("month")

--- a/plots.js
+++ b/plots.js
@@ -107,7 +107,9 @@ function datasetsToMonth(config) {
         var visualization = d3plus.viz()
             .data(data)
             .title("Total Datasets")
-            .title("Due to an aggregation issue, current count does not include ~82,000 datasets from https://data.inrae.fr")
+            .title({
+               "sub": "Due to an aggregation issue, current count does not include ~82,000 datasets from https://data.inrae.fr",
+               "total": true
             .container("#datasets-to-month")
             .type("bar")
             .id("month")

--- a/plots.js
+++ b/plots.js
@@ -107,7 +107,7 @@ function datasetsToMonth(config) {
         var visualization = d3plus.viz()
             .data(data)
             .title("Total Datasets")
-            .subtitle("Currently does not include ~82,000 datasets from https://data.inrae.fr due to an aggregation issue")
+            .subtitle("Due to an aggregation issue, current count does not include ~82,000 datasets from https://data.inrae.fr")
             .container("#datasets-to-month")
             .type("bar")
             .id("month")

--- a/plots.js
+++ b/plots.js
@@ -107,6 +107,7 @@ function datasetsToMonth(config) {
         var visualization = d3plus.viz()
             .data(data)
             .title("Total Datasets")
+            .subtitle("Currently does not include ~82,000 datasets from https://data.inrae.fr due to an aggregation issue")
             .container("#datasets-to-month")
             .type("bar")
             .id("month")

--- a/plots.js
+++ b/plots.js
@@ -107,7 +107,7 @@ function datasetsToMonth(config) {
         var visualization = d3plus.viz()
             .data(data)
             .title("Total Datasets")
-            .subtitle("Due to an aggregation issue, current count does not include ~82,000 datasets from https://data.inrae.fr")
+            .title("Due to an aggregation issue, current count does not include ~82,000 datasets from https://data.inrae.fr")
             .container("#datasets-to-month")
             .type("bar")
             .id("month")

--- a/plots.js
+++ b/plots.js
@@ -108,8 +108,7 @@ function datasetsToMonth(config) {
             .data(data)
             .title("Total Datasets")
             .title({
-               "sub": "Due to an aggregation issue, current count does not include ~82,000 datasets from https://data.inrae.fr",
-               "total": true
+               "sub": "Due to an aggregation issue, current count does not include ~82,000 datasets from https://data.inrae.fr"
             })
             .container("#datasets-to-month")
             .type("bar")


### PR DESCRIPTION
The Metrics app is encountering some issues due to how INRA and Manitoba have configured their Dataverse installations. Instead of making the changes in the Metrics app itself, we are asking the installations to make updates to their configuration. While we wait for these installations to update, we are going to add a note on the Metrics app itself, primarily to explain the large drop in Dataset #s from month-to-month due to the outsize # of datasets in INRA.

This is my attempt at doing this - adding a subtitle element to the D3 chart. 