### PR TITLE
Removing params from URL when creating link

### DIFF
--- a/installationplots.js
+++ b/installationplots.js
@@ -532,7 +532,7 @@ function addAlias() {
 
 //Turn dataverse names into links to the metrics page using that dataverse as the parent
 function updateNames(node) {
-  node.name = "<a href='" + window.location + "?parentAlias=" + node.alias + "'>" + node.alias + "</a>";
+  node.name = "<a href='" + window.location.href.split("?")[0] + "?parentAlias=" + node.alias + "'>" + node.alias + "</a>";
   if (typeof node.children !== 'undefined') {
     node.children.forEach((childnode) => {
       updateNames(childnode);


### PR DESCRIPTION
Fixes Wrong links in tree selection when two or more levels deep; https://github.com/IQSS/dataverse-metrics/issues/81
