### PR TITLE
Remove hardcoded URL in menu backlink

### DIFF
--- a/installationplots.js
+++ b/installationplots.js
@@ -45,7 +45,7 @@ $(document).ready(function() {
       $('#selectString').html('<div>Click a sub-' + config.dataverseTerm + ' name to see its metrics</div>');
     } else {
       $('#subtitle').html("<h2>Showing Metrics from the " + alias + " " + config.dataverseTerm + "</h2>");
-      $('#selectString').html('<div><a href="/dataverse-metrics">Show Metrics for the whole repository</a></div><div>Click a sub-' + config.dataverseTerm + ' name to see its metrics</div>');
+      $('#selectString').html('<div><a href= "' + window.location.href.split('?')[0] +'">Show Metrics for the whole repository</a></div><div>Click a sub-' + config.dataverseTerm + ' name to see its metrics</div>');
     }
     
     //Panels


### PR DESCRIPTION
When testing #82, I noticed that the backlink in the collection tree to "Show Metrics for the whole repository" was hardcoded and therefore didn't work unless the app is deployed at /dataverse-metrics. The fix below, using the same syntax as #82, fixes that and correctly returns to the whole repository page regardless of deployed location.