### PR TITLE
Issue 79: Making configurable if Make Data Count is rendered

### DIFF
--- a/config.local.json.sample
+++ b/config.local.json.sample
@@ -44,6 +44,7 @@
     "makeDataCount/viewsTotal/monthly": "#6c757d",
     "makeDataCount/downloadsTotal/monthly": "#006699",
     "makeDataCount/viewsUnique/monthly": "#224F20",
-    "makeDataCount/downloadsUnique/monthly": "#b22200"
+    "makeDataCount/downloadsUnique/monthly": "#b22200", 
+    "makeDataCount": true
   }
 }

--- a/config.local.json.sample
+++ b/config.local.json.sample
@@ -4,6 +4,7 @@
   "dataverseTerm": "Dataverse",
   "datasetTerm": "Dataset",
   "downloadsHeader": "Downloads",
+  "makeDataCount": true,
   "makeDataCountHeader": "Make Data Count",
   "holdingsHeader": "Holdings",
   "timeseries.dataverses.definition":"Total Number of published Dataverses as a function of time.",
@@ -44,7 +45,6 @@
     "makeDataCount/viewsTotal/monthly": "#6c757d",
     "makeDataCount/downloadsTotal/monthly": "#006699",
     "makeDataCount/viewsUnique/monthly": "#224F20",
-    "makeDataCount/downloadsUnique/monthly": "#b22200", 
-    "makeDataCount": true
+    "makeDataCount/downloadsUnique/monthly": "#b22200"
   }
-}
+ }

--- a/installationplots.js
+++ b/installationplots.js
@@ -85,13 +85,19 @@ $(document).ready(function() {
     multitimeseries("UniqueDownloads", config, "pid");
     //Row 7 - by Count and by Size graphs
     filesByType(config);
-    //Row 8
-    makeDataCount("viewsTotal", config);
-    makeDataCount("downloadsTotal", config);
-    //Row 9
-    makeDataCount("viewsUnique", config);
-    makeDataCount("downloadsUnique", config);
-
+    
+    // Use MDC by default, is backwards compatible
+    if (!config.hasOwnProperty("makeDataCount") || config.makeDataCount) {
+      //Row 8
+      makeDataCount("viewsTotal", config);
+      makeDataCount("downloadsTotal", config);
+      //Row 9
+      makeDataCount("viewsUnique", config);
+      makeDataCount("downloadsUnique", config);
+    } else {
+      // No MDC
+      $("#mdcSection").parent().hide();
+    }
   });
 });
 


### PR DESCRIPTION
Fixing #79 
Add configuration option to show 'Make Data Count' metrics or not.  
The json is: `    "makeDataCount": true`, but when unspecified it is `true`. 
When set to `false` the MDC panel is hidden and also no backend calls are made to retrieve the information. 
