### PR TITLE
stop hitting URLs with a .. in the path

### DIFF
--- a/download.py
+++ b/download.py
@@ -105,6 +105,8 @@ def process_single_endpoints(installation, single_endpoints, api_response_cache_
 
 def process_single_endpoint(installation, endpoint, api_response_cache_dir, user_agent):
     url = installation + '/api/info/metrics/' + endpoint
+    if endpoint == '../version':
+        url = installation + '/api/info/version'
     try:
         req = urlrequest.Request(url, headers={'User-Agent': user_agent})
         req.add_header('Accept', 'application/json')


### PR DESCRIPTION
- Closes #97

https://demo.dataverse.org/api/info/metrics/../version for example works in a browser but for some sites we're seeing errors like this:

<urlopen error [Errno 54] Connection reset by peer>
https://example.com had an oops: <urlopen error [Errno 54] Connection reset by peer>

See also discussion in Zulip: https://dataverse.zulipchat.com/#narrow/stream/379673-dev/topic/metrics/near/457182440

`../version` was originally added in https://github.com/IQSS/dataverse-metrics/commit/41d13233e85318d38185148e056668ad0049949a